### PR TITLE
Adjust safe frame layout to respect safe areas

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -59,17 +59,12 @@ body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  padding: var(--safe-top) var(--safe-right) var(--safe-bottom) var(--safe-left);
 }
 
 .safe-frame {
-  position: fixed;
-  top: var(--safe-top);
-  right: var(--safe-right);
-  bottom: var(--safe-bottom);
-  left: var(--safe-left);
   display: flex;
   flex-direction: column;
-  overflow: hidden;
   contain: layout paint size;
   z-index: 0;
 }
@@ -98,8 +93,7 @@ body.is-menu-closing {
 .safe-frame .content {
   position: relative;
   flex: 1 1 auto;
-  height: 100%;
-  overflow: auto;
+  min-height: 100%;
   -webkit-overflow-scrolling: touch;
 }
 


### PR DESCRIPTION
## Summary
- allow the safe-frame container to participate in normal layout flow while keeping its flex column stack
- shift safe-area inset management to the body so page scrolling respects unsafe regions
- ensure the safe-frame content stretches via min-height instead of forcing its own scrolling container

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8468d54e483319a47a0fc9893c310