### PR TITLE
Ensure safe-frame maintains viewport height in flow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -59,18 +59,16 @@ body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  padding: var(--safe-top) var(--safe-right) var(--safe-bottom) var(--safe-left);
 }
 
 .safe-frame {
-  position: fixed;
-  top: var(--safe-top);
-  right: var(--safe-right);
-  bottom: var(--safe-bottom);
-  left: var(--safe-left);
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  contain: layout paint size;
+  min-height: 100vh;
+  min-height: 100svh;
+  min-height: 100dvh;
+  min-height: calc((var(--viewport-unit) * 100) - (var(--safe-top) + var(--safe-bottom)));
   z-index: 0;
 }
 
@@ -98,8 +96,7 @@ body.is-menu-closing {
 .safe-frame .content {
   position: relative;
   flex: 1 1 auto;
-  height: 100%;
-  overflow: auto;
+  min-height: 100%;
   -webkit-overflow-scrolling: touch;
 }
 


### PR DESCRIPTION
## Summary
- give the safe-frame a viewport-based min-height stack so it still stretches to fill the screen after rejoining normal layout flow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8468d54e483319a47a0fc9893c310